### PR TITLE
Set RX Antenna

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ build
 
 Testing.txt
 examples/top_block.py
+.ropeproject

--- a/examples/flex-source.grc
+++ b/examples/flex-source.grc
@@ -352,7 +352,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(32, 181)</value>
+      <value>(40, 174)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -369,6 +369,10 @@
     <param>
       <key>minoutbuf</key>
       <value>0</value>
+    </param>
+    <param>
+      <key>rx_ant</key>
+      <value>ANT1</value>
     </param>
   </block>
   <block>

--- a/grc/flex_source.xml
+++ b/grc/flex_source.xml
@@ -30,8 +30,27 @@
   <param>
     <name>RX Antenna</name>
     <key>rx_ant</key>
-    <value>ANT1</value>
     <type>string</type>
+    <option>
+      <name>ANT1</name>
+      <key>ANT1</key>
+    </option>
+    <option>
+      <name>ANT2</name>
+      <key>ANT2</key>
+    </option>
+    <option>
+      <name>RX A</name>
+      <key>RX_A</key>
+    </option>
+    <option>
+      <name>RX B</name>
+      <key>RX_B</key>
+    </option>
+    <option>
+      <name>XVTR</name>
+      <key>XVTR</key>
+    </option>
   </param>
 
   <!-- Make one 'sink' node per input. Sub-nodes:

--- a/grc/flex_source.xml
+++ b/grc/flex_source.xml
@@ -4,9 +4,10 @@
   <key>flex_source</key>
   <category>Flex Radio</category>
   <import>import flex</import>
-  <make>flex.FlexSource($center_freq, $bandwidth)</make>
+  <make>flex.FlexSource($center_freq, $bandwidth, $rx_ant)</make>
   <callback>set_center_freq($center_freq)</callback>
   <callback>set_bandwidth($bandwidth)</callback>
+  <callback>set_rx_ant($rx_ant)</callback>
   <!-- Make one 'param' node for every Parameter you want settable from the GUI.
        Sub-nodes:
        * name
@@ -24,6 +25,13 @@
     <key>bandwidth</key>
     <value>5000000</value>
     <type>float</type>
+  </param>
+
+  <param>
+    <name>RX Antenna</name>
+    <key>rx_ant</key>
+    <value>ANT1</value>
+    <type>string</type>
   </param>
 
   <!-- Make one 'sink' node per input. Sub-nodes:

--- a/python/FlexSource.py
+++ b/python/FlexSource.py
@@ -31,8 +31,7 @@ from RingBuffer import RingBuffer
 
 class FlexSource(gr.sync_block):
     """
-    The FlexSource block used for streaming and interacting with IQ Data Streams
-    from the Flex Radio.
+    The FlexSource block used for streaming and interacting with IQ Data Streams from the Flex Radio.
     """
     def __init__(self, center_freq=15000000, bandwidth=5000000, rx_ant="ANT1"):
         gr.sync_block.__init__(self,

--- a/python/FlexSource.py
+++ b/python/FlexSource.py
@@ -34,13 +34,14 @@ class FlexSource(gr.sync_block):
     The FlexSource block used for streaming and interacting with IQ Data Streams
     from the Flex Radio.
     """
-    def __init__(self, center_freq=15000000, bandwidth=5000000):
+    def __init__(self, center_freq=15000000, bandwidth=5000000, rx_ant="ANT1"):
         gr.sync_block.__init__(self,
                                name="source",
                                in_sig=None,
                                out_sig=[numpy.float32])
         self._center_freq = self.__hz_to_mhz(center_freq)
         self._bandwidth = self.__hz_to_mhz(bandwidth)
+        self._rx_ant = rx_ant
         print "FLEX:SOURCE:INIT"
         self.rx_buffer = None
         self.radio = None
@@ -85,6 +86,13 @@ class FlexSource(gr.sync_block):
         self._bandwidth = self.__hz_to_mhz(bandwidth)
         self.pan_adapter.Bandwidth = self._bandwidth
 
+    @property
+    def rx_ant(self):
+        """
+        Returns RX antenna in use.
+        """
+        return self._rx_ant
+
     def __iq_data_received(self, iq_stream, data):
         try:
             # Add the data to the receive buffer
@@ -125,10 +133,11 @@ class FlexSource(gr.sync_block):
         self.pan_adapter = self.radio.GetOrCreatePanadapterSync(0, 0)
         #self.pan_adapter.PropertyChanged += self.__property_changed
 
-        print "FlexSource::Panadapter created (ch:{0}, center freq:{1} MHz, bandwidth:{2} MHz)".format(dax_ch,self.center_freq,self.bandwidth)
+        print "FlexSource::Panadapter created (ch:{0}, center freq:{1} MHz, bandwidth:{2} MHz, RX antenna:{3} )".format(dax_ch,self.center_freq,self.bandwidth,self.rx_ant)
         self.pan_adapter.DAXIQChannel = dax_ch
         self.pan_adapter.CenterFreq = self.center_freq
         self.pan_adapter.Bandwidth = self.bandwidth
+        self.pan_adapter.RXAnt = self.rx_ant
 
         print "FlexSource::CreatingIQStream"
         self.iq_stream = self.radio.CreateIQStreamSync(dax_ch)

--- a/python/FlexSource.py
+++ b/python/FlexSource.py
@@ -93,6 +93,16 @@ class FlexSource(gr.sync_block):
         """
         return self._rx_ant
 
+    def set_rx_ant(self,rx_ant):
+        """
+        Sets the RX antenna of the underlying Panadapter
+
+        Args:
+            rx_ant: the new RX antenna to use
+        """
+        self._rx_ant = self.rx_ant
+        self.pan_adapter.RXAnt = self._rx_ant
+
     def __iq_data_received(self, iq_stream, data):
         try:
             # Add the data to the receive buffer

--- a/python/FlexSource.py
+++ b/python/FlexSource.py
@@ -49,7 +49,7 @@ class FlexSource(gr.sync_block):
         self.pan_adapter = None
 
     def __hz_to_mhz(self, hz):
-        mhz = hz/1000000
+        mhz = hz / 1000000
         return mhz
 
     @property
@@ -59,7 +59,7 @@ class FlexSource(gr.sync_block):
         """
         return self._center_freq
 
-    def set_center_freq(self,center_freq):
+    def set_center_freq(self, center_freq):
         """
         Sets the center frequency of the underlying Panadapter
 
@@ -76,7 +76,7 @@ class FlexSource(gr.sync_block):
         """
         return self._bandwidth
 
-    def set_bandwidth(self,bandwidth):
+    def set_bandwidth(self, bandwidth):
         """
         Sets the bandwidth of the underlying Panadapter
 
@@ -93,7 +93,7 @@ class FlexSource(gr.sync_block):
         """
         return self._rx_ant
 
-    def set_rx_ant(self,rx_ant):
+    def set_rx_ant(self, rx_ant):
         """
         Sets the RX antenna of the underlying Panadapter
 
@@ -126,7 +126,7 @@ class FlexSource(gr.sync_block):
         - Creates IQ Stream and begins listening
     """
     def start(self):
-        self.rx_buffer = RingBuffer(4096) # 4 times the UDP payload size
+        self.rx_buffer = RingBuffer(4096)  # 4 times the UDP payload size
         print "FlexSource::Starting..."
         self.radio = FlexApi().getRadio()
 
@@ -141,9 +141,9 @@ class FlexSource(gr.sync_block):
         for p in pans:
             p.Close(True)
         self.pan_adapter = self.radio.GetOrCreatePanadapterSync(0, 0)
-        #self.pan_adapter.PropertyChanged += self.__property_changed
+        # self.pan_adapter.PropertyChanged += self.__property_changed
 
-        print "FlexSource::Panadapter created (ch:{0}, center freq:{1} MHz, bandwidth:{2} MHz, RX antenna:{3} )".format(dax_ch,self.center_freq,self.bandwidth,self.rx_ant)
+        print "FlexSource::Panadapter created (ch:{0}, center freq:{1} MHz, bandwidth:{2} MHz, RX antenna:{3} )".format(dax_ch, self.center_freq, self.bandwidth, self.rx_ant)
         self.pan_adapter.DAXIQChannel = dax_ch
         self.pan_adapter.CenterFreq = self.center_freq
         self.pan_adapter.Bandwidth = self.bandwidth
@@ -165,7 +165,7 @@ class FlexSource(gr.sync_block):
         self.pan_adapter.Close(True)
         self.iq_stream.Close()
         del self.rx_buffer
-        #self.received_queue.join()
+        # self.received_queue.join()
         print("FlexSource::Removed IQ & Panadapter, finished Queue")
         return True
 


### PR DESCRIPTION
The FlexSource can now check which RX Antenna is active as well as change the RX Ant port on the flex in use. The GRC block now has a dropdown which lets you pick which RX Ant to use. 

The only "maybe-bug" is that while the flowgraph is running, changing the RX Ant value doesn't seem to matter. So you can pick before launch which antenna to use but you can't change during operation.