### PR TITLE
Allow setting dax iq from block

### DIFF
--- a/examples/flex-source.grc
+++ b/examples/flex-source.grc
@@ -208,53 +208,6 @@
     </param>
   </block>
   <block>
-    <key>variable_text_box</key>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>converver</key>
-      <value>eval_converter</value>
-    </param>
-    <param>
-      <key>value</key>
-      <value>1</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>formatter</key>
-      <value>None</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(712, 44)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>grid_pos</key>
-      <value></value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>dax_iq_ch</value>
-    </param>
-    <param>
-      <key>label</key>
-      <value>DAX</value>
-    </param>
-    <param>
-      <key>notebook</key>
-      <value></value>
-    </param>
-  </block>
-  <block>
     <key>variable</key>
     <param>
       <key>comment</key>
@@ -403,7 +356,7 @@
     </param>
     <param>
       <key>dax_iq_ch</key>
-      <value>dax_iq_ch</value>
+      <value>1</value>
     </param>
     <param>
       <key>_enabled</key>

--- a/examples/flex-source.grc
+++ b/examples/flex-source.grc
@@ -208,6 +208,53 @@
     </param>
   </block>
   <block>
+    <key>variable_text_box</key>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>converver</key>
+      <value>eval_converter</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>1</value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>formatter</key>
+      <value>None</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(712, 44)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>grid_pos</key>
+      <value></value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>dax_iq_ch</value>
+    </param>
+    <param>
+      <key>label</key>
+      <value>DAX</value>
+    </param>
+    <param>
+      <key>notebook</key>
+      <value></value>
+    </param>
+  </block>
+  <block>
     <key>variable</key>
     <param>
       <key>comment</key>
@@ -258,7 +305,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(272, 177)</value>
+      <value>(272, 248)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -309,7 +356,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(480, 177)</value>
+      <value>(480, 248)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -356,7 +403,7 @@
     </param>
     <param>
       <key>dax_iq_ch</key>
-      <value>1</value>
+      <value>dax_iq_ch</value>
     </param>
     <param>
       <key>_enabled</key>
@@ -364,7 +411,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(40, 176)</value>
+      <value>(40, 248)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -427,7 +474,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(664, 213)</value>
+      <value>(1064, 284)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -538,7 +585,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(664, 36)</value>
+      <value>(1064, 108)</value>
     </param>
     <param>
       <key>_rotation</key>

--- a/examples/flex-source.grc
+++ b/examples/flex-source.grc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<?grc format='1' created='3.7.9'?>
+<?grc format='1' created='3.7.12'?>
 <flow_graph>
   <timestamp>Wed Sep 27 14:37:17 2017</timestamp>
   <block>
@@ -73,12 +73,20 @@
       <value>True</value>
     </param>
     <param>
+      <key>sizing_mode</key>
+      <value>fixed</value>
+    </param>
+    <param>
       <key>thread_safe_setters</key>
       <value></value>
     </param>
     <param>
       <key>title</key>
       <value></value>
+    </param>
+    <param>
+      <key>placement</key>
+      <value>(0,0)</value>
     </param>
   </block>
   <block>
@@ -347,12 +355,16 @@
       <value></value>
     </param>
     <param>
+      <key>dax_iq_ch</key>
+      <value>1</value>
+    </param>
+    <param>
       <key>_enabled</key>
       <value>True</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(40, 174)</value>
+      <value>(40, 176)</value>
     </param>
     <param>
       <key>_rotation</key>

--- a/grc/flex_source.xml
+++ b/grc/flex_source.xml
@@ -4,7 +4,7 @@
   <key>flex_source</key>
   <category>Flex Radio</category>
   <import>import flex</import>
-  <make>flex.FlexSource($center_freq, $bandwidth, $rx_ant)</make>
+  <make>flex.FlexSource($center_freq, $bandwidth, $rx_ant, $dax_iq_ch)</make>
   <callback>set_center_freq($center_freq)</callback>
   <callback>set_bandwidth($bandwidth)</callback>
   <callback>set_rx_ant($rx_ant)</callback>
@@ -54,9 +54,6 @@
     </option>
   </param>
 
-  <!-- Can this be done iteratively?
-       I'm stuck on a ferry without
-       internet... XML is lame.     -->
   <param>
     <name>DAX IQ Channel</name>
     <key>dax_iq_ch</key>

--- a/grc/flex_source.xml
+++ b/grc/flex_source.xml
@@ -8,6 +8,7 @@
   <callback>set_center_freq($center_freq)</callback>
   <callback>set_bandwidth($bandwidth)</callback>
   <callback>set_rx_ant($rx_ant)</callback>
+  <callback>set_dax_iq_ch($dax_iq_ch)</callback>
   <!-- Make one 'param' node for every Parameter you want settable from the GUI.
        Sub-nodes:
        * name
@@ -50,6 +51,63 @@
     <option>
       <name>XVTR</name>
       <key>XVTR</key>
+    </option>
+  </param>
+
+  <!-- Can this be done iteratively?
+       I'm stuck on a ferry without
+       internet... XML is lame.     -->
+  <param>
+    <name>DAX IQ Channel</name>
+    <key>dax_iq_ch</key>
+    <type>int</type>
+    <option>
+      <name>1</name>
+      <key>1</key>
+    </option>
+    <option>
+      <name>2</name>
+      <key>2</key>
+    </option>
+    <option>
+      <name>3</name>
+      <key>3</key>
+    </option>
+    <option>
+      <name>4</name>
+      <key>4</key>
+    </option>
+    <option>
+      <name>5</name>
+      <key>5</key>
+    </option>
+    <option>
+      <name>6</name>
+      <key>6</key>
+    </option>
+    <option>
+      <name>7</name>
+      <key>7</key>
+    </option>
+    <option>
+      <name>8</name>
+      <key>8</key>
+    </option>
+    <option>
+      <name>9</name>
+      <key>9</key>
+    </option>
+    <option>
+      <name>10</name>
+      <key>10</key>
+    </option>
+    <option>
+      <name>11</name>
+      <key>11</key>
+    </option>
+    <option>
+      <name>12</name>
+      <key>12</key>
     </option>
   </param>
 

--- a/grc/flex_source.xml
+++ b/grc/flex_source.xml
@@ -62,10 +62,6 @@
     <key>dax_iq_ch</key>
     <type>int</type>
     <option>
-      <name>None</name>
-      <key>0</key>
-    </option>
-    <option>
       <name>1</name>
       <key>1</key>
     </option>

--- a/grc/flex_source.xml
+++ b/grc/flex_source.xml
@@ -62,6 +62,10 @@
     <key>dax_iq_ch</key>
     <type>int</type>
     <option>
+      <name>None</name>
+      <key>0</key>
+    </option>
+    <option>
       <name>1</name>
       <key>1</key>
     </option>
@@ -76,38 +80,6 @@
     <option>
       <name>4</name>
       <key>4</key>
-    </option>
-    <option>
-      <name>5</name>
-      <key>5</key>
-    </option>
-    <option>
-      <name>6</name>
-      <key>6</key>
-    </option>
-    <option>
-      <name>7</name>
-      <key>7</key>
-    </option>
-    <option>
-      <name>8</name>
-      <key>8</key>
-    </option>
-    <option>
-      <name>9</name>
-      <key>9</key>
-    </option>
-    <option>
-      <name>10</name>
-      <key>10</key>
-    </option>
-    <option>
-      <name>11</name>
-      <key>11</key>
-    </option>
-    <option>
-      <name>12</name>
-      <key>12</key>
     </option>
   </param>
 

--- a/python/FlexSource.py
+++ b/python/FlexSource.py
@@ -130,11 +130,11 @@ class FlexSource(gr.sync_block):
         except Exception as err:
             print err
 
-    # If uncommenting, also see the += line in def start(self)
+    """# If uncommenting, also see the += line in def start(self)
     def __property_changed(self, sender, args):
         if args.PropertyName == "DAXIQChannel":
             print "{0} DAXIQChannel Changed".format(self.pan_adapter.DAXIQChannel)
-
+    """
 
     """
     Start method of GNU Block:
@@ -147,9 +147,8 @@ class FlexSource(gr.sync_block):
         print "FlexSource::Starting..."
         self.radio = FlexApi().getRadio()
 
-        # TODO: make these parameters of source block
-        # dax_ch = 1 # if exposure via block is working you can remove this line
-        sample_rate = 192000
+        # TODO: make this a parameter of the source block
+        sample_rate = 192000 # Available in IQStream.cs
 
         print "FlexSource::GetOrCreatePanAdapter"
         pans = self.radio.WaitForPanadaptersSync()
@@ -158,7 +157,7 @@ class FlexSource(gr.sync_block):
         for p in pans:
             p.Close(True)
         self.pan_adapter = self.radio.GetOrCreatePanadapterSync(0, 0)
-        self.pan_adapter.PropertyChanged += self.__property_changed
+        # self.pan_adapter.PropertyChanged += self.__property_changed
 
         print "FlexSource::Panadapter created (DAX IQ Ch:{0}, center freq:{1} MHz, bandwidth:{2} MHz, RX antenna:{3} )".format(self.dax_iq_ch, self.center_freq, self.bandwidth, self.rx_ant)
         self.pan_adapter.DAXIQChannel = self.dax_iq_ch
@@ -204,14 +203,3 @@ class FlexSource(gr.sync_block):
             pass
 
         return num_outputs
-
-
-        #     for i in range(0, out.size - 1):
-        #         num = self.received_queue.get_nowait()
-        #         #out[i] = self.received_queue.get_nowait()
-        #         #self.received_queue.task_done()
-        #         #num_outputs = i
-        # except Queue.Empty:
-        #     # Happens when the queue is empty, no prob
-        #     pass
-        # return num_outputs

--- a/python/FlexSource.py
+++ b/python/FlexSource.py
@@ -117,8 +117,13 @@ class FlexSource(gr.sync_block):
         Args:
             dax_iq_ch: the new DAX IQ channel to use
         """
+        print 'HI IM HERE TO SET THE DAX IQ CHANNEL'
+        print 'BEFORE I START: self.dax_iq_ch={0}'.format(self.dax_iq_ch)
         self._dax_iq_ch = self.dax_iq_ch
+        print 'CHANGED A BIT: self._dax_iq_ch={0}'.format(self._dax_iq_ch)
+        print 'pan_DAX={0}'.format(self.pan_adapter.DAXIQChannel)
         self.pan_adapter.DAXIQChannel = self._dax_iq_ch
+        print 'pan_DAX take 2={0}'.format(self.pan_adapter.DAXIQChannel)
 
     def __iq_data_received(self, iq_stream, data):
         try:
@@ -158,7 +163,7 @@ class FlexSource(gr.sync_block):
         for p in pans:
             p.Close(True)
         self.pan_adapter = self.radio.GetOrCreatePanadapterSync(0, 0)
-        # self.pan_adapter.PropertyChanged += self.__property_changed
+        self.pan_adapter.PropertyChanged += self.__property_changed
 
         print "FlexSource::Panadapter created (DAX IQ Ch:{0}, center freq:{1} MHz, bandwidth:{2} MHz, RX antenna:{3} )".format(self.dax_iq_ch, self.center_freq, self.bandwidth, self.rx_ant)
         self.pan_adapter.DAXIQChannel = self.dax_iq_ch

--- a/python/FlexSource.py
+++ b/python/FlexSource.py
@@ -130,11 +130,11 @@ class FlexSource(gr.sync_block):
         except Exception as err:
             print err
 
-    """ # If uncommenting, also see the += line in def start(self)
+    # If uncommenting, also see the += line in def start(self)
     def __property_changed(self, sender, args):
-        if args.PropertyName == "Bandwidth":
-            print "{0} Bandwidth Changed".format(self.pan_adapter.Bandwidth)
-    """
+        if args.PropertyName == "DAXIQChannel":
+            print "{0} DAXIQChannel Changed".format(self.pan_adapter.DAXIQChannel)
+
 
     """
     Start method of GNU Block:

--- a/python/FlexSource.py
+++ b/python/FlexSource.py
@@ -33,7 +33,7 @@ class FlexSource(gr.sync_block):
     """
     The FlexSource block used for streaming and interacting with IQ Data Streams from the Flex Radio.
     """
-    def __init__(self, center_freq=15000000, bandwidth=5000000, rx_ant="ANT1"):
+    def __init__(self, center_freq=15000000, bandwidth=5000000, rx_ant="ANT1", dax_iq_ch=1):
         gr.sync_block.__init__(self,
                                name="source",
                                in_sig=None,
@@ -41,6 +41,7 @@ class FlexSource(gr.sync_block):
         self._center_freq = self.__hz_to_mhz(center_freq)
         self._bandwidth = self.__hz_to_mhz(bandwidth)
         self._rx_ant = rx_ant
+        self._dax_iq_ch = dax_iq_ch
         print "FLEX:SOURCE:INIT"
         self.rx_buffer = None
         self.radio = None
@@ -102,6 +103,23 @@ class FlexSource(gr.sync_block):
         self._rx_ant = self.rx_ant
         self.pan_adapter.RXAnt = self._rx_ant
 
+    @property
+    def dax_iq_ch(self):
+        """
+        Returns dax_iq_ch in use.
+        """
+        return self._dax_iq_ch
+
+    def set_dax_iq_ch(self, dax_iq_ch):
+        """
+        Sets the DAX IQ channel of the underlying Panadapter
+
+        Args:
+            dax_iq_ch: the new DAX IQ channel to use
+        """
+        self._dax_iq_ch = self.dax_iq_ch
+        self.pan_adapter.DAXIQChannel = self._dax_iq_ch
+
     def __iq_data_received(self, iq_stream, data):
         try:
             # Add the data to the receive buffer
@@ -130,7 +148,7 @@ class FlexSource(gr.sync_block):
         self.radio = FlexApi().getRadio()
 
         # TODO: make these parameters of source block
-        dax_ch = 1
+        # dax_ch = 1 # if exposure via block is working you can remove this line
         sample_rate = 192000
 
         print "FlexSource::GetOrCreatePanAdapter"
@@ -143,7 +161,7 @@ class FlexSource(gr.sync_block):
         # self.pan_adapter.PropertyChanged += self.__property_changed
 
         print "FlexSource::Panadapter created (ch:{0}, center freq:{1} MHz, bandwidth:{2} MHz, RX antenna:{3} )".format(dax_ch, self.center_freq, self.bandwidth, self.rx_ant)
-        self.pan_adapter.DAXIQChannel = dax_ch
+        self.pan_adapter.DAXIQChannel = self.dax_iq_ch
         self.pan_adapter.CenterFreq = self.center_freq
         self.pan_adapter.Bandwidth = self.bandwidth
         self.pan_adapter.RXAnt = self.rx_ant

--- a/python/FlexSource.py
+++ b/python/FlexSource.py
@@ -117,13 +117,8 @@ class FlexSource(gr.sync_block):
         Args:
             dax_iq_ch: the new DAX IQ channel to use
         """
-        print 'HI IM HERE TO SET THE DAX IQ CHANNEL'
-        print 'BEFORE I START: self.dax_iq_ch={0}'.format(self.dax_iq_ch)
         self._dax_iq_ch = self.dax_iq_ch
-        print 'CHANGED A BIT: self._dax_iq_ch={0}'.format(self._dax_iq_ch)
-        print 'pan_DAX={0}'.format(self.pan_adapter.DAXIQChannel)
         self.pan_adapter.DAXIQChannel = self._dax_iq_ch
-        print 'pan_DAX take 2={0}'.format(self.pan_adapter.DAXIQChannel)
 
     def __iq_data_received(self, iq_stream, data):
         try:

--- a/python/FlexSource.py
+++ b/python/FlexSource.py
@@ -160,14 +160,14 @@ class FlexSource(gr.sync_block):
         self.pan_adapter = self.radio.GetOrCreatePanadapterSync(0, 0)
         # self.pan_adapter.PropertyChanged += self.__property_changed
 
-        print "FlexSource::Panadapter created (ch:{0}, center freq:{1} MHz, bandwidth:{2} MHz, RX antenna:{3} )".format(dax_ch, self.center_freq, self.bandwidth, self.rx_ant)
+        print "FlexSource::Panadapter created (DAX IQ Ch:{0}, center freq:{1} MHz, bandwidth:{2} MHz, RX antenna:{3} )".format(self.dax_iq_ch, self.center_freq, self.bandwidth, self.rx_ant)
         self.pan_adapter.DAXIQChannel = self.dax_iq_ch
         self.pan_adapter.CenterFreq = self.center_freq
         self.pan_adapter.Bandwidth = self.bandwidth
         self.pan_adapter.RXAnt = self.rx_ant
 
         print "FlexSource::CreatingIQStream"
-        self.iq_stream = self.radio.CreateIQStreamSync(dax_ch)
+        self.iq_stream = self.radio.CreateIQStreamSync(self.dax_iq_ch)
         self.iq_stream.DataReady += self.__iq_data_received
         self.iq_stream.SampleRate = sample_rate
         print "FlexSource::IQStreamCreated"


### PR DESCRIPTION
Like the RX Antenna exposure, you can set it ahead of time but live switching does not work.